### PR TITLE
Update Java lexing rules for character literals.

### DIFF
--- a/java5/java.l
+++ b/java5/java.l
@@ -102,7 +102,7 @@ strictfp "STRICTFP"
 ellipsis "ELLIPSIS"
 enum "ENUM"
 
-'(?:\\'|[^'\n])*' "CHARACTER_LITERAL"
+'([^\t\n\r\f\\'\\]|\\[tnfr'"\\]|\\[0-3][0-7][0-7]|\\u[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])' "CHARACTER_LITERAL"
 "(?:\\"|[^"\n])*" "STRING_LITERAL"
 /[*].*?[*]/ ;
 

--- a/java7/java.l
+++ b/java7/java.l
@@ -102,7 +102,7 @@ instanceof "INSTANCEOF"
 null "NULL_LITERAL"
 [a-zA-Z_$][a-zA-Z0-9_$]* "IDENTIFIER"
 
-'(?:\\\\|\\'|[^'\n])*' "CHARACTER_LITERAL"
+'([^\t\n\r\f\\'\\]|\\[tnfr'"\\]|\\[0-3][0-7][0-7]|\\u[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])' "CHARACTER_LITERAL"
 "(?:\\\\|\\"|[^"\n])*" "STRING_LITERAL"
 /[*].*?[*]/ ;
 


### PR DESCRIPTION
According to the Java specification only the following is allowed between single quotes:

- Any printable character other than a backslash or '
- Escaped characters: \b \t \n \f \r \" \' \\
- Escaped octal number between 000 and 377 (e.g. \123)
- Esacped Unicode, e.g. \u012A