### PR TITLE
resolve reduce/reduce conflict in Lua's grammar

### DIFF
--- a/lua53/lua53.y
+++ b/lua53/lua53.y
@@ -59,6 +59,7 @@
 %epp DOTDOT ".."
 %epp DOTDOTDOT "..."
 %expect 1
+%expect-rr 1
 %%
 block
     : statlistopt retstatopt;


### PR DESCRIPTION
There is an inherent ambiguity in the current Lua's grammar that leads to 1 shift/reduce and 1 reduce/reduce conflict.

```
# cargo build
   Compiling lua v0.0.1 (/home/repair/lua)
error: failed to run custom build command for `lua v0.0.1 (/home/repair/lua)`

Caused by:
  process didn't exit successfully: `/home/repair/lua/target/debug/build/lua-cf6cf1af0ff1e418/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at build.rs:14:10:
  called `Result::unwrap()` on an `Err` value: CTConflictsError{1 Reduce/Reduce, 1 Shift/Reduce}
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The error happens even when the following grammar directive is present:
```
%expect 1
```

To resolve the issue, I had to include both directives:
```
%expect 1
%expect-rr 1
```


